### PR TITLE
Updated images pointing to new balenalabs organization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   # BalenaLabs WiFi-Connect
   # ------------------------------------------------------------------------------------
   wifi-connect:
-    image: balenablocks/wifi-connect:rpi
+    image: bh.cr/balenalabs/wifi-connect-rpi
     container_name: wifi-connect
     network_mode: "host"
     labels:
@@ -27,7 +27,7 @@ services:
   # Node-RED
   # ------------------------------------------------------------------------------------
   node-red:
-    image: bh.cr/balenablocks/balena-node-red
+    image: bh.cr/balenalabs/balena-node-red
     container_name: node-red
     privileged: true
     restart: unless-stopped
@@ -67,7 +67,7 @@ services:
   # Grafana
   # ------------------------------------------------------------------------------------
   grafana:
-    image: balenablocks/dashboard
+    image: bh.cr/balenalabs/dashboard
     container_name: grafana
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Please check this [forum post](https://forums.balena.io/t/ming-project-mqtt-influxdb-nodered-and-grafana/365355/15?u=alexcorvis84). 

As far as I've checked, projects have been moved to the new **balenalabs** organization.